### PR TITLE
Update dogm-graphic.h

### DIFF
--- a/dogm-graphic.h
+++ b/dogm-graphic.h
@@ -444,7 +444,7 @@ void lcd_move_xy    (int8_t pages, int16_t columns);
   #define LCD_GOTO_ADDRESS(page,col)   lcd_command(LCD_PAGE_ADDRESS | ((page) & 0x0F)); \
                                        lcd_command((((col)+SHIFT_ADDR) & 0x0F)); \
                                        lcd_command(LCD_COL_ADDRESS | ((((col)+SHIFT_ADDR)>>4) & 0x0F))
-  #define LCD_TEMPCOMP_HIGH  0x90
+  #define LCD_TEMPCOMP_HIGH  0x80
   #define LCD_COLWRAP        0x02
   #define LCD_PAGEWRAP       0x01
   #define LCD_SET_ADV_PROG_CTRL(i)     lcd_command(LCD_ADV_PROG_CTRL); \

--- a/dogm-graphic.h
+++ b/dogm-graphic.h
@@ -441,10 +441,10 @@ void lcd_move_xy    (int8_t pages, int16_t columns);
   #define LCD_SET_PAGE_ADDR(i)         lcd_command(LCD_PAGE_ADDRESS | ((i) & 0x0F))
   #define LCD_SET_COLUMN_ADDR(col)     lcd_command((((col)+SHIFT_ADDR) & 0x0F)); \
                                        lcd_command(LCD_COL_ADDRESS | ((((col)+SHIFT_ADDR)>>4) & 0x0F))
-  #define LCD_GOTO_ADDRESS(page,col)   lcd_command(LCD_PAGE_ADDRESS | ((page) & 0x1F)); \
+  #define LCD_GOTO_ADDRESS(page,col)   lcd_command(LCD_PAGE_ADDRESS | ((page) & 0x0F)); \
                                        lcd_command((((col)+SHIFT_ADDR) & 0x0F)); \
                                        lcd_command(LCD_COL_ADDRESS | ((((col)+SHIFT_ADDR)>>4) & 0x0F))
-  #define LCD_TEMPCOMP_HIGH  0x80
+  #define LCD_TEMPCOMP_HIGH  0x90
   #define LCD_COLWRAP        0x02
   #define LCD_PAGEWRAP       0x01
   #define LCD_SET_ADV_PROG_CTRL(i)     lcd_command(LCD_ADV_PROG_CTRL); \


### PR DESCRIPTION
The command in line 444 should be the same as in line 441 and according to EA datasheet and UC1701 datasheet the last four (not 5) bits are the page-address. 
It probably only rarely becomes an issue, if users never target an address > 15
The command for setting temperature compensation mode is [TC, 0, 0, 1], so it should be 0x90 for high and 0x10 for low (also stated in both datasheets, so I assume correct).

Did not have the chance to confirm on hardware yet, whether the mistake is in the code or the datasheets, but at least the first is either incorrect on line 444 or 441. Thought I better post it now, before I forget.